### PR TITLE
Fix area select on landing page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1090,7 +1090,6 @@
 			"integrity": "sha512-vByReCTTdlNM80vva8alAQC80HcOiHLkd8XAxIiKghKSHcqeNfyhp3VsYAV8VSiPKu4Jc8wWCfsZNAIvd1uCqA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@standard-schema/spec": "^1.0.0",
 				"@sveltejs/acorn-typescript": "^1.0.5",
@@ -1130,7 +1129,6 @@
 			"integrity": "sha512-0ba1RQ/PHen5FGpdSrW7Y3fAMQjrXantECALeOiOdBdzR5+5vPP6HVZRLmZaQL+W8m++o+haIAKq5qT+MiZ7VA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@sveltejs/vite-plugin-svelte-inspector": "^3.0.0-next.0||^3.0.0",
 				"debug": "^4.3.7",
@@ -1686,7 +1684,6 @@
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -1793,7 +1790,8 @@
 			"version": "0.5.3",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
 			"integrity": "sha512-RwBeO/B/vZR3dfKL1ye/vx8MHZ40ugzpyfeVG5GsiuGnrlMWe2o8wxBbLCpw9CsxV+wHuzYlCiWnybrIA0ling==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/commander": {
 			"version": "7.2.0",
@@ -2585,8 +2583,7 @@
 			"resolved": "https://registry.npmjs.org/pym.js/-/pym.js-1.3.2.tgz",
 			"integrity": "sha512-/fFzHFB4BTsJQP5id0wzUdYsDT4VPkfAxk+uENBE9/aP6YbvhAEpcuJHdjxqisqfXOCrcz7duTK1fbtF2rz8RQ==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/quickselect": {
 			"version": "3.0.0",
@@ -2751,7 +2748,6 @@
 			"integrity": "sha512-2074U+vObO5Zs8/qhxtBwdi6ZXNIhEBTzNmUFjiZexLxTdt9vq96D/0pnQELl6YcpLMD7pZ2dhXKByfGS8SAdg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@jridgewell/remapping": "^2.3.4",
 				"@jridgewell/sourcemap-codec": "^1.5.0",
@@ -2829,7 +2825,6 @@
 			"integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.21.3",
 				"postcss": "^8.4.43",

--- a/src/lib/ui/Select.svelte
+++ b/src/lib/ui/Select.svelte
@@ -142,7 +142,7 @@
 
   const dispatch = createEventDispatcher();
 
-  export let id = "";
+  export let id = "select";
   export let idKey = "areacd";
   export let labelKey = "areanm";
   export let groupKey = "group";

--- a/src/routes/(embed)/landing/+page.svelte
+++ b/src/routes/(embed)/landing/+page.svelte
@@ -25,6 +25,7 @@
     constituencies.</label
   >
   <Select
+    id="area-search"
     autoClear={false}
     placeholder="Type an area name or postcode"
     listMaxHeight={130}


### PR DESCRIPTION
The area search/select box has not been showing up on the [embedded landing page](https://www.ons.gov.uk/peoplepopulationandcommunity/populationandmigration/populationestimates/articles/buildacustomareaprofile/2023-01-17) for BaCAP since we moved to accessible-autocomplete search. This PR should fix this issue.