### PR TITLE
Radius + eraser tool fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"@mapbox/mapbox-gl-draw": "^1.3.0",
 				"@mapbox/tilebelt": "^1.0.2",
 				"@mapbox/vector-tile": "^1.3.1",
-				"@onsvisual/svelte-components": "^1.0.39",
+				"@onsvisual/svelte-components": "^1.0.47",
 				"@sveltejs/adapter-static": "^3.0.0",
 				"@sveltejs/kit": "^2.5.27",
 				"@sveltejs/vite-plugin-svelte": "^4.0.0",
@@ -729,9 +729,9 @@
 			}
 		},
 		"node_modules/@onsvisual/svelte-components": {
-			"version": "1.0.39",
-			"resolved": "https://registry.npmjs.org/@onsvisual/svelte-components/-/svelte-components-1.0.39.tgz",
-			"integrity": "sha512-gFEiIYWRBR6UsrL/rd8b+bFLMqCXZSesjT/+I1/ZxIDzvkWmIf/wg0AmWdZFCD4xkhgc3bATjDlgbVCyXpI8sw==",
+			"version": "1.0.47",
+			"resolved": "https://registry.npmjs.org/@onsvisual/svelte-components/-/svelte-components-1.0.47.tgz",
+			"integrity": "sha512-BqN2xUgo57+cDmFXyPaWH+mj9vTJEsXkY+i1ckSEogpnU0caxHp5HpUSYUYtxp5mAbq2stQOhpv2iQkxaHf5sA==",
 			"dev": true,
 			"optionalDependencies": {
 				"@rollup/rollup-linux-x64-gnu": "^4.52.4"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"@mapbox/mapbox-gl-draw": "^1.3.0",
 		"@mapbox/tilebelt": "^1.0.2",
 		"@mapbox/vector-tile": "^1.3.1",
-		"@onsvisual/svelte-components": "^1.0.39",
+		"@onsvisual/svelte-components": "^1.0.47",
 		"@sveltejs/adapter-static": "^3.0.0",
 		"@sveltejs/kit": "^2.5.27",
 		"@sveltejs/vite-plugin-svelte": "^4.0.0",

--- a/src/lib/layout/DrawToolbar.svelte
+++ b/src/lib/layout/DrawToolbar.svelte
@@ -14,6 +14,7 @@ export let state;
 export let radius=0.5;
 
 $:updateLocalStorage($state.name)
+$:console.log({radius})
 </script>
 
 <div style="z-index:99;position:relative;pointer-events:none;">

--- a/src/routes/(main)/draw/+page.svelte
+++ b/src/routes/(main)/draw/+page.svelte
@@ -78,6 +78,7 @@
   } //endinit
 
   onMount(init);
+  $: console.log("radius", $radiusInKm);
 
   // $:console.log('selected',$selected)
 </script>


### PR DESCRIPTION
This PR should fix the issue that the radius/eraser tools were fixed to 1km (changing the selection would not change the radius drawn on the map).

There was an underlying issue that the "value" prop of the svelte-components ButtonGroup component was not explicitly set to $bindable()